### PR TITLE
Fix: Correct frontend API endpoint URLs for restaurant menu CRUD

### DIFF
--- a/frontend/templates/restaurants/category_form.html
+++ b/frontend/templates/restaurants/category_form.html
@@ -125,7 +125,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function loadCategoryData(categoryId) {
-        fetchAPI(`/api/categories/${categoryId}/`)
+        fetchAPI(`/api/restaurants/categories/${categoryId}/`)
             .then(data => {
                 categoryNameInput.value = data.name || '';
                 categoryDescriptionInput.value = data.description || '';
@@ -170,7 +170,7 @@ document.addEventListener('DOMContentLoaded', function() {
             restaurant: myRestaurantId
         };
 
-        let url = '/api/categories/';
+        let url = '/api/restaurants/categories/';
         let method = 'POST';
 
         if (isEditMode) {

--- a/frontend/templates/restaurants/manage_menu.html
+++ b/frontend/templates/restaurants/manage_menu.html
@@ -138,7 +138,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Delete category
     function deleteCategory(categoryId, categoryName) {
         if (confirmAction(`Are you sure you want to delete the category "${categoryName}" and all its items?`)) {
-            fetchAPI(`/api/categories/${categoryId}/`, 'DELETE')
+            fetchAPI(`/api/restaurants/categories/${categoryId}/`, 'DELETE')
                 .then(() => {
                     showToast(`Category "${categoryName}" deleted successfully.`);
                     loadMenuData();
@@ -153,7 +153,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Delete menu item
     function deleteMenuItem(itemId, itemName) {
         if (confirmAction(`Are you sure you want to delete the menu item "${itemName}"?`)) {
-            fetchAPI(`/api/menu-items/${itemId}/`, 'DELETE')
+            fetchAPI(`/api/restaurants/menu-items/${itemId}/`, 'DELETE')
                 .then(() => {
                     showToast(`Menu item "${itemName}" deleted successfully.`);
                     loadMenuData();
@@ -168,7 +168,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Toggle item availability
     function toggleItemAvailability(itemId, itemName, currentStatus) {
         const newStatus = !currentStatus;
-        fetchAPI(`/api/menu-items/${itemId}/`, 'PATCH', {
+        fetchAPI(`/api/restaurants/menu-items/${itemId}/`, 'PATCH', {
             is_available: newStatus
         })
         .then(() => {
@@ -184,7 +184,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Toggle item featured status
     function toggleItemFeatured(itemId, itemName, currentStatus) {
         const newStatus = !currentStatus;
-        fetchAPI(`/api/menu-items/${itemId}/`, 'PATCH', {
+        fetchAPI(`/api/restaurants/menu-items/${itemId}/`, 'PATCH', {
             is_featured: newStatus
         })
         .then(() => {
@@ -200,7 +200,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Toggle category active status
     function toggleCategoryActive(categoryId, categoryName, currentStatus) {
         const newStatus = !currentStatus;
-        fetchAPI(`/api/categories/${categoryId}/`, 'PATCH', {
+        fetchAPI(`/api/restaurants/categories/${categoryId}/`, 'PATCH', {
             is_active: newStatus
         })
         .then(() => {
@@ -249,7 +249,7 @@ document.addEventListener('DOMContentLoaded', function() {
             
             // Update each category with its new order
             Promise.all(newOrder.map(item => 
-                fetchAPI(`/api/categories/${item.id}/`, 'PATCH', { order: item.order })
+                fetchAPI(`/api/restaurants/categories/${item.id}/`, 'PATCH', { order: item.order })
             ))
             .then(() => {
                 showToast('Category order updated successfully.');

--- a/frontend/templates/restaurants/menu_item_form.html
+++ b/frontend/templates/restaurants/menu_item_form.html
@@ -188,7 +188,7 @@ document.addEventListener('DOMContentLoaded', function() {
     function loadCategories(selectedCategoryId = null) {
         if (!myRestaurantId) return;
         
-        fetchAPI(`/api/categories/?restaurant=${myRestaurantId}`)
+        fetchAPI(`/api/restaurants/categories/?restaurant=${myRestaurantId}`)
             .then(data => {
                 const categories = data.results || data;
                 itemCategorySelect.innerHTML = '<option value="">Select a category...</option>';
@@ -248,7 +248,7 @@ document.addEventListener('DOMContentLoaded', function() {
         });
 
     function loadMenuItemData(itemId) {
-        fetchAPI(`/api/menu-items/${itemId}/`)
+        fetchAPI(`/api/restaurants/menu-items/${itemId}/`)
             .then(data => {
                 itemNameInput.value = data.name || '';
                 itemDescriptionInput.value = data.description || '';
@@ -315,7 +315,7 @@ document.addEventListener('DOMContentLoaded', function() {
         // Add restaurant ID
         formData.append('restaurant', myRestaurantId);
 
-        let url = '/api/menu-items/';
+        let url = '/api/restaurants/menu-items/';
         let method = 'POST';
 
         if (isEditMode) {


### PR DESCRIPTION
This commit resolves a 404 error you experienced when performing CRUD operations (e.g., adding a category) from the restaurant management UI. The issue was due to incorrect API base paths used in the JavaScript within frontend templates.

The following files were modified to use the correct `/api/restaurants/` prefix for relevant API calls:
- `frontend/templates/restaurants/category_form.html`
- `frontend/templates/restaurants/menu_item_form.html`
- `frontend/templates/restaurants/manage_menu.html`

All API calls for categories (e.g., to `/api/categories/`) and menu items (e.g., to `/api/menu-items/`) made from these templates have been updated to their correct paths (e.g.,
`/api/restaurants/categories/` and `/api/restaurants/menu-items/`).

Automated tests were run after these changes, and all tests pass.