### PR TITLE
Enhance Order Details API and Consolidate Restaurant API

### DIFF
--- a/api_changes_report.md
+++ b/api_changes_report.md
@@ -1,0 +1,61 @@
+# API Changes Report
+
+This report summarizes the recent enhancements to the Order Details API and clarifications regarding the Restaurant List API.
+
+## 1. Order Details API Enhancement
+
+*   **Endpoint:** `GET /orders/{order_id}/`
+    *   This is the standard retrieve action for the `OrderViewSet`. The exact URL depends on the router configuration in `urls.py`, but typically defaults to this pattern.
+*   **Description:** This API now returns a comprehensive, nested JSON structure for order details, providing a richer set of information for a single order.
+*   **Key Changes:**
+    *   The response for fetching a single order has been significantly expanded. It now includes detailed, nested objects for:
+        *   `status`: Contains the `current` status of the order and a `timeline` of all `OrderStatusEventSerializer` (status, timestamp, completed flag).
+        *   `restaurant`: Detailed information about the restaurant via `RestaurantDetailSerializer` (`id`, `name`, placeholder `cuisine`, calculated `rating`, placeholder `deliveryTime`).
+        *   `customer`: Detailed information about the customer via `CustomerDetailSerializer` (`id`, `name`, `phone`).
+        *   `deliveryAddress`: Detailed delivery address information via `DeliveryAddressSerializer` (placeholders for `street`, `city`, `state`, `zipCode`, `country` from the single `delivery_address` field, `fullAddress`, nested `coordinates` from `delivery_lat`/`lng`, and placeholder `mapImageUrl`).
+        *   `items`: A list of ordered items, with each item using `OrderItemDetailSerializer`. This includes `id` (OrderItem ID), `name` (MenuItem name), `description` (MenuItem description), `quantity`, `unitPrice` (OrderItem unit price), calculated `totalPrice`, `imageUrl` (MenuItem image), `category` (MenuItem category name), placeholder `customizations`, and `specialInstructions` (OrderItem notes).
+        *   `pricing`: A breakdown of pricing via `PricingDetailSerializer` (calculated `subtotal` from item subtotals, `deliveryFee`, placeholders for `serviceFee`, `tax`, `tip`, `discount` from Order, and `total` from Order).
+        *   `payment`: Placeholder payment details via `PaymentDetailSerializer` (placeholder `method`, `cardLast4`, `cardType`, `transactionId`, `status`).
+        *   `delivery`: Delivery-related information via `DeliveryDetailSerializer` (placeholder `type`, `estimatedTime` from Order, placeholder `actualDeliveryTime`, nested `driver` details (nullable), and `instructions` from Order notes).
+        *   `timestamps`: Key order timestamps via `OrderTimestampDetailSerializer` (`ordered` for 'PLACED' status, `confirmed` for 'CONFIRMED' status, `delivered` for 'DELIVERED' status).
+    *   Many fields that were not directly available in the database models have been included as placeholders (e.g., `restaurant.cuisine`, `restaurant.deliveryTime`, parsed address components in `deliveryAddress` like `street`/`city`/`state`/`zipCode`/`country`, `deliveryAddress.mapImageUrl`, `orderItem.customizations`, `pricing.serviceFee`/`tax`/`tip`, all fields in `payment`, `delivery.type`, `delivery.actualDeliveryTime`, `driver.rating`). These will either require backend model/logic updates to populate accurately or should be handled as display-only with placeholder/default values in the UI.
+    *   The `metadata` field has been excluded from the order details response as requested.
+*   **Action:**
+    *   The UI team should adapt the order details view to consume this new, richer, and more nested JSON structure.
+    *   Be mindful of the placeholder fields and discuss with the backend team which of these will be fully implemented versus those that will remain static placeholders.
+
+## 2. Restaurant List API Consolidation
+
+*   **Endpoint:** `GET /restaurants/` (typically, or `/restaurants/list/` if explicitly configured by a custom router, but standard ViewSet list routes are usually at the base path). The `RestaurantViewSet` also includes a specific search action at `GET /restaurants/search/?q={query}`.
+*   **Description:** This is confirmed as the primary and sole API for fetching a list of restaurants. The `RestaurantViewSet` provides comprehensive listing, filtering (e.g., `is_open`), and searching capabilities.
+*   **Key Changes:**
+    *   No endpoints were removed. The investigation confirmed that the existing `RestaurantViewSet` (accessible via `/restaurants/` and its sub-paths like `/restaurants/search/`) is the correct and most comprehensive API for restaurant listings.
+    *   The endpoint supports filtering by fields like `is_open` and full-text search on `name`, `address`, and `description` via query parameters (e.g., `/restaurants/?is_open=true`, `/restaurants/search/?q=pizza`). Ordering is also supported.
+*   **Action:**
+    *   The UI team should continue using the `GET /restaurants/` endpoint (and its search variant `GET /restaurants/search/`) for displaying restaurant lists and implementing search/filter functionalities.
+
+## 3. Order Item Details
+
+*   **Context:** This is part of the **Order Details API Enhancement** (`GET /orders/{order_id}/`).
+*   **Description:** As mentioned in section 1, each item within the `items` array of the order detail response (`OrderDetailSerializer`) now uses `OrderItemDetailSerializer`.
+*   **Key Information per Item:**
+    *   `id`: The ID of the `OrderItem` itself.
+    *   `name`: Name of the `MenuItem`.
+    *   `description`: Description of the `MenuItem`.
+    *   `quantity`: Quantity ordered.
+    *   `unitPrice`: Price per unit for this specific order item (could differ from current menu item price if it changed).
+    *   `totalPrice`: Calculated as `quantity * unitPrice`.
+    *   `imageUrl`: Image of the `MenuItem`.
+    *   `category`: Name of the `MenuCategory` for the item.
+    *   `customizations`: Placeholder field (currently returns an empty list).
+    *   `specialInstructions`: Notes added by the customer for this specific item.
+
+## 4. General Notes
+
+*   **No API Removals:**
+    *   No order detail APIs were removed. The existing `OrderViewSet`'s `retrieve` action was enhanced to return the new `OrderDetailSerializer`.
+    *   No restaurant list APIs were removed, as the primary endpoint provided by `RestaurantViewSet` was found to be unique, appropriate, and feature-rich.
+*   **Metadata Exclusion:** The `metadata` field, if it existed previously or was a concern, has been explicitly excluded from the new `OrderDetailSerializer` response.
+*   **Placeholder Fields:** A significant number of fields in the new `OrderDetailSerializer` are placeholders due to lack of direct corresponding data in the current database models or business logic. These are clearly marked in the serializer definitions (e.g., returning `None` or a static string like "To be implemented"). These will require further backend work to become dynamic or will be acknowledged as static placeholders.
+
+This report should provide clarity to the UI team on how to adapt to the updated API responses.

--- a/orders/serializers.py
+++ b/orders/serializers.py
@@ -1,9 +1,92 @@
+from django.db.models import Avg
 from rest_framework import serializers
 from .models import Order, OrderItem, OrderStatusUpdate
-from restaurants.models import MenuItem, Restaurant
+from users.models import CustomUser # Added
+from restaurants.models import MenuItem, Restaurant, RestaurantReview # Added RestaurantReview
 from django.db import transaction
 from django.utils import timezone
 
+# --- Detail Serializers ---
+
+class CustomerDetailSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(source='full_name')
+
+    class Meta:
+        model = CustomUser
+        fields = ['id', 'name', 'phone']
+        read_only_fields = ['id', 'name', 'phone']
+
+
+class RestaurantDetailSerializer(serializers.ModelSerializer):
+    cuisine = serializers.SerializerMethodField()
+    rating = serializers.SerializerMethodField()
+    deliveryTime = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Restaurant
+        fields = ['id', 'name', 'cuisine', 'rating', 'deliveryTime']
+        read_only_fields = ['id', 'name', 'cuisine', 'rating', 'deliveryTime']
+
+    def get_cuisine(self, obj):
+        # Placeholder: Restaurant model does not have a cuisine field
+        return "To be implemented" # Or None
+
+    def get_rating(self, obj):
+        # Calculate average rating from RestaurantReview
+        average_rating = RestaurantReview.objects.filter(restaurant=obj).aggregate(Avg('rating'))['rating__avg']
+        return round(average_rating, 1) if average_rating else None
+
+    def get_deliveryTime(self, obj):
+        # Placeholder: Restaurant model does not have a deliveryTime field
+        return "To be implemented" # Or None
+
+
+class CoordinatesSerializer(serializers.Serializer): # Must be defined before DeliveryAddressSerializer
+    latitude = serializers.DecimalField(max_digits=9, decimal_places=6, source='delivery_lat', required=False, allow_null=True)
+    longitude = serializers.DecimalField(max_digits=9, decimal_places=6, source='delivery_lng', required=False, allow_null=True)
+
+
+class DeliveryAddressSerializer(serializers.ModelSerializer):
+    street = serializers.SerializerMethodField()
+    city = serializers.SerializerMethodField()
+    state = serializers.SerializerMethodField()
+    zipCode = serializers.SerializerMethodField()
+    country = serializers.SerializerMethodField()
+    fullAddress = serializers.CharField(source='delivery_address', read_only=True)
+    coordinates = CoordinatesSerializer(source='*', read_only=True)
+    mapImageUrl = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Order
+        fields = ['street', 'city', 'state', 'zipCode', 'country', 'fullAddress', 'coordinates', 'mapImageUrl']
+        read_only_fields = fields
+
+    def get_street(self, obj):
+        # Placeholder: Order.delivery_address is a single TextField. Parsing logic would go here.
+        return None
+
+    def get_city(self, obj):
+        # Placeholder
+        return None
+
+    def get_state(self, obj):
+        # Placeholder
+        return None
+
+    def get_zipCode(self, obj):
+        # Placeholder
+        return None
+
+    def get_country(self, obj):
+        # Placeholder
+        return None
+
+    def get_mapImageUrl(self, obj):
+        # Placeholder: No map image URL in the model
+        return "https://maps.example.com/staticmap?center=..." # Or None
+
+
+# --- Existing Serializers ---
 
 class OrderItemSerializer(serializers.ModelSerializer):
     menu_item_name = serializers.CharField(source='menu_item.name', read_only=True)
@@ -158,3 +241,217 @@ class OrderListSerializer(serializers.ModelSerializer):
 
     def get_item_count(self, obj) -> int:
         return obj.items.count()
+
+
+# --- Additional Detail Serializers ---
+
+class OrderItemDetailSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(source='menu_item.name', read_only=True)
+    description = serializers.CharField(source='menu_item.description', read_only=True)
+    totalPrice = serializers.SerializerMethodField(read_only=True)
+    imageUrl = serializers.ImageField(source='menu_item.image', read_only=True, allow_null=True)
+    category = serializers.CharField(source='menu_item.category.name', read_only=True, allow_null=True)
+    customizations = serializers.SerializerMethodField(read_only=True) # Placeholder
+    specialInstructions = serializers.CharField(source='notes', read_only=True, allow_null=True)
+    unitPrice = serializers.DecimalField(source='unit_price', max_digits=10, decimal_places=2, read_only=True)
+
+
+    class Meta:
+        model = OrderItem
+        fields = ['id', 'name', 'description', 'quantity', 'unitPrice', 'totalPrice',
+                  'imageUrl', 'category', 'customizations', 'specialInstructions']
+        read_only_fields = ['id', 'name', 'description', 'quantity', 'unitPrice', 'totalPrice',
+                            'imageUrl', 'category', 'customizations', 'specialInstructions']
+
+    def get_totalPrice(self, obj):
+        return obj.quantity * obj.unit_price
+
+    def get_customizations(self, obj):
+        # Placeholder for customizations
+        return []
+
+
+class PricingDetailSerializer(serializers.ModelSerializer):
+    subtotal = serializers.SerializerMethodField()
+    serviceFee = serializers.SerializerMethodField() # Placeholder
+    tax = serializers.SerializerMethodField() # Placeholder
+    tip = serializers.SerializerMethodField() # Placeholder
+    total = serializers.DecimalField(source='total_price', max_digits=10, decimal_places=2, read_only=True)
+    deliveryFee = serializers.DecimalField(source='delivery_fee', max_digits=10, decimal_places=2, read_only=True)
+    # discount is already on Order model
+
+    class Meta:
+        model = Order
+        fields = ['subtotal', 'deliveryFee', 'serviceFee', 'tax', 'tip', 'discount', 'total']
+        read_only_fields = fields
+
+    def get_subtotal(self, obj):
+        # Sum of all order item subtotals
+        return sum(item.subtotal for item in obj.items.all())
+
+    def get_serviceFee(self, obj):
+        # Placeholder
+        return None
+
+    def get_tax(self, obj):
+        # Placeholder
+        return None
+
+    def get_tip(self, obj):
+        # Placeholder
+        return None
+
+
+class PaymentDetailSerializer(serializers.Serializer): # No model backing this directly for now
+    method = serializers.SerializerMethodField()
+    cardLast4 = serializers.SerializerMethodField()
+    cardType = serializers.SerializerMethodField()
+    transactionId = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+
+    class Meta:
+        fields = ['method', 'cardLast4', 'cardType', 'transactionId', 'status']
+        read_only_fields = fields
+
+    def get_method(self, obj):
+        return "Placeholder Payment Method" # e.g., "Credit Card"
+
+    def get_cardLast4(self, obj):
+        return "0000" # Placeholder
+
+    def get_cardType(self, obj):
+        return "Visa" # Placeholder
+
+    def get_transactionId(self, obj):
+        return "placeholder_transaction_id" # Placeholder
+
+    def get_status(self, obj):
+        return "Completed" # Placeholder, assumes payment was successful for a retrieved order
+
+
+class DriverDetailSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(source='full_name', read_only=True)
+    rating = serializers.SerializerMethodField() # Placeholder
+
+    class Meta:
+        model = CustomUser # Assuming driver is a CustomUser
+        fields = ['id', 'name', 'phone', 'rating']
+        read_only_fields = ['id', 'name', 'phone', 'rating']
+
+    def get_rating(self, obj):
+        # Placeholder: Driver rating not on CustomUser model
+        return None # Or a default like 5.0
+
+
+class DeliveryDetailSerializer(serializers.ModelSerializer):
+    type = serializers.SerializerMethodField() # Placeholder
+    estimatedTime = serializers.DateTimeField(source='estimated_delivery_time', read_only=True)
+    actualDeliveryTime = serializers.SerializerMethodField() # Placeholder
+    # Assuming 'driver' might be a ForeignKey on Order or accessed via a related model like DriverTask
+    # For now, this will be None if not directly on Order.
+    driver = DriverDetailSerializer(read_only=True, allow_null=True, required=False)
+    instructions = serializers.CharField(source='notes', read_only=True, allow_null=True) # Using order notes as delivery instructions
+
+    class Meta:
+        model = Order
+        fields = ['type', 'estimatedTime', 'actualDeliveryTime', 'driver', 'instructions']
+        read_only_fields = fields
+
+    def get_type(self, obj):
+        # Placeholder
+        return "Standard Delivery"
+
+    def get_actualDeliveryTime(self, obj):
+        # Placeholder: This would be set when the order is actually delivered
+        return None
+
+
+class OrderStatusEventSerializer(serializers.ModelSerializer):
+    timestamp = serializers.DateTimeField(source='created_at', read_only=True)
+    completed = serializers.SerializerMethodField(read_only=True)
+
+    class Meta:
+        model = OrderStatusUpdate
+        fields = ['status', 'timestamp', 'completed']
+        read_only_fields = fields
+
+    def get_completed(self, obj):
+        # 'obj' is an OrderStatusUpdate instance.
+        order_current_status = self.context.get('order_current_status')
+        # An event is "completed" if its status is different from the order's current overall status.
+        # This is a simplification; a more complex system might have a defined flow.
+        if order_current_status:
+            return obj.status != order_current_status
+        # Fallback if context isn't provided, though it always should be by OrderStatusDetailSerializer.
+        # Consider if this event is the *absolute latest* update for the order. If not, it's 'completed'.
+        # However, this requires comparing its timestamp to the latest overall, which is tricky here.
+        # The current logic relies on `order_current_status` being correctly passed.
+        return False
+
+
+class OrderStatusDetailSerializer(serializers.ModelSerializer):
+    current = serializers.CharField(source='status', read_only=True) # Current status of the Order
+    timeline = serializers.SerializerMethodField(read_only=True)
+
+    class Meta:
+        model = Order # Source is the Order model
+        fields = ['current', 'timeline']
+        read_only_fields = fields
+
+    def get_timeline(self, obj):
+        # 'obj' is an Order instance.
+        # status_updates are ordered by '-created_at' by default in OrderStatusUpdate.Meta
+        status_updates = obj.status_updates.all()
+        # Provide the order's current status to the event serializer's context
+        context = {**self.context, 'order_current_status': obj.status}
+        return OrderStatusEventSerializer(status_updates, many=True, context=context, read_only=True).data
+
+
+class OrderTimestampDetailSerializer(serializers.ModelSerializer):
+    ordered = serializers.SerializerMethodField()
+    confirmed = serializers.SerializerMethodField()
+    delivered = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Order # Source is the Order model
+        fields = ['ordered', 'confirmed', 'delivered']
+        read_only_fields = fields
+
+    def get_timestamp_for_status(self, obj, status_value):
+        # Helper to get the creation timestamp of the first status update matching status_value
+        status_update = obj.status_updates.filter(status=status_value).order_by('created_at').first()
+        return status_update.created_at if status_update else None
+
+    def get_ordered(self, obj):
+        # Timestamp of the 'PLACED' status
+        return self.get_timestamp_for_status(obj, 'PLACED')
+
+    def get_confirmed(self, obj):
+        # Timestamp of the 'CONFIRMED' status
+        return self.get_timestamp_for_status(obj, 'CONFIRMED')
+
+    def get_delivered(self, obj):
+        # Timestamp of the 'DELIVERED' status
+        return self.get_timestamp_for_status(obj, 'DELIVERED')
+
+
+class OrderDetailSerializer(serializers.ModelSerializer):
+    orderNumber = serializers.CharField(source='id', read_only=True) # Using UUID as orderNumber for simplicity
+    status = OrderStatusDetailSerializer(source='*', read_only=True) # Pass the whole Order instance
+    restaurant = RestaurantDetailSerializer(read_only=True)
+    customer = CustomerDetailSerializer(read_only=True)
+    deliveryAddress = DeliveryAddressSerializer(source='*', read_only=True) # Pass the whole Order instance
+    items = OrderItemDetailSerializer(many=True, read_only=True, source='items') # Explicit source for items
+    pricing = PricingDetailSerializer(source='*', read_only=True) # Pass the whole Order instance
+    payment = PaymentDetailSerializer(source='*', read_only=True) # Pass the whole Order instance (all placeholders)
+    delivery = DeliveryDetailSerializer(source='*', read_only=True) # Pass the whole Order instance
+    timestamps = OrderTimestampDetailSerializer(source='*', read_only=True) # Pass the whole Order instance
+
+    class Meta:
+        model = Order
+        fields = [
+            'id', 'orderNumber', 'status', 'restaurant', 'customer',
+            'deliveryAddress', 'items', 'pricing', 'payment', 'delivery', 'timestamps'
+        ]
+        # All fields are read-only as this is a "Detail" serializer for retrieve actions
+        read_only_fields = fields

--- a/orders/views.py
+++ b/orders/views.py
@@ -10,7 +10,8 @@ from .serializers import (
     OrderListSerializer,
     OrderItemSerializer,
     OrderStatusUpdateSerializer,
-    OrderUpdateSerializer
+    OrderUpdateSerializer,
+    OrderDetailSerializer # Added
 )
 from .filters import OrderFilter
 from users.permissions import IsCustomer, IsRestaurantOwner, IsDriver, IsAdminUser
@@ -72,9 +73,11 @@ class OrderViewSet(viewsets.ModelViewSet):
     def get_serializer_class(self):
         if self.action == 'list':
             return OrderListSerializer
+        elif self.action == 'retrieve': # Added this condition
+            return OrderDetailSerializer
         elif self.action == 'update' or self.action == 'partial_update':
             return OrderUpdateSerializer
-        return OrderSerializer
+        return OrderSerializer # Default for create and other actions
     
     def get_queryset(self):
         user = self.request.user


### PR DESCRIPTION
I've refactored the Order Details API (`GET /orders/{id}/`) to provide a comprehensive, nested JSON response. This includes detailed information for the order, customer, restaurant, delivery address, order items (with full menu item details), pricing, payment (placeholders), delivery (placeholders), and status timeline.

- I created new serializers in `orders/serializers.py` (e.g., `OrderDetailSerializer`, `CustomerDetailSerializer`, `RestaurantDetailSerializer`, `OrderItemDetailSerializer`, etc.) to support the new structure.
- I updated `OrderViewSet` in `orders/views.py` to use `OrderDetailSerializer` for the retrieve action.
- I excluded 'metadata' from the order details response as you requested.

I verified that the existing Restaurant List API (`GET /restaurants/list/` and its search variant) is the sole and comprehensive endpoint. No redundant restaurant list APIs were found or removed.

The `OrderItemDetailSerializer` ensures that items listed in the order details now include rich menu information like description, image URL, and category.

I've generated a report detailing these changes for the UI team (`api_changes_report.md`).